### PR TITLE
socket has been defined in turbo, but AF_UNIX has not

### DIFF
--- a/consts_h.lua
+++ b/consts_h.lua
@@ -1,0 +1,6 @@
+local ffi = require('ffi')
+
+ffi.cdef[[
+static const int AF_UNIX = 1;
+static const int SOCK_DGRAM = 2;
+]]

--- a/socket.lua
+++ b/socket.lua
@@ -1,5 +1,8 @@
 local cur_path = (...):match("(.-)[^%(.|/)]+$")
 local ffi = require("ffi")
+if pcall(function() return ffi.C.AF_UNIX end) == false then
+    require(cur_path..'consts_h')
+end
 if pcall(function() return ffi.C.socket end) == false then
     require(cur_path..'socket_h')
 end

--- a/socket_h.lua
+++ b/socket_h.lua
@@ -1,8 +1,6 @@
 local ffi = require('ffi')
 
 ffi.cdef[[
-static const int AF_UNIX = 1;
-static const int SOCK_DGRAM = 2;
 struct sockaddr {
   short unsigned int sa_family;
   char sa_data[14];


### PR DESCRIPTION
After update turbo package, socket has been defined in ffi.C, but AF_UNIT has not. So this change separates AF_UNIX and socket into two _h.lua file.