### PR TITLE
fix: filter out more bad lines in wpa scan result

### DIFF
--- a/wpaclient.lua
+++ b/wpaclient.lua
@@ -105,7 +105,7 @@ function WpaClient.__index:getScanResults()
     for _,v in ipairs(lst) do
         local splits = str_split(v, '\t')
 
-        if splits[5] then  -- remove lines which cannot split into 5 parts
+        if splits[5] then  -- ignore lines which don't split into 5 parts
             local network = {
                 bssid = splits[1],
                 frequency = tonumber(splits[2]),


### PR DESCRIPTION
Sometime wpa scan result contain useless line cause parsing fail. E.g.,

```sh
OK  # this is a bad line
bssid / frequency / signal level / flags / ssid
c6:e9:84:64:28:b7	2437	100	[WPA2-PSK-CCMP][ESS]	bgap
c4:e9:84:66:28:b7	2437	100	[WPA2-PSK-CCMP][WPS][ESS]	bigap
c4:e9:84:46:34:c4	2437	60	[WPA-PSK-CCMP][WPA2-PSK-CCMP][ESS]	smallap
```

This patch try to fix it out.

See here for more detail:

https://github.com/koreader/koreader/issues/3436#issuecomment-340379302