### PR TITLE
Try to avoid mangling the RSSI too much

### DIFF
--- a/wpaclient.lua
+++ b/wpaclient.lua
@@ -97,7 +97,7 @@ function network_mt.__index:getSignalQuality()
     -- which means every driver kinda does what it wants with it...
 
     -- So, at the very least, attempt to detect those that report it as a dBm value, because it'll be negative.
-    if self.signal_level < 0
+    if self.signal_level < 0 then
         -- Actually hitting 0 dBm is highly unlikely, but, assuming [-100, 0] nonetheless appears to give consistent
         -- results across the WiFi drivers used on Kobo devices...
         return self.signal_level + 100

--- a/wpaclient.lua
+++ b/wpaclient.lua
@@ -92,8 +92,16 @@ end
 local network_mt = {__index = {}}
 
 function network_mt.__index:getSignalQuality()
-    -- convert from RSSI to signal quality in range of [0%, 100%].
-    return math.min(math.max((self.signal_level + 100) * 2, 0), 100)
+    -- Make sure the RSSI is in a positive range (hopefully one that's in the ballpark of [0%, 100%]).
+    -- There's no real silver bullet here, as the RSSI is in arbitrary units,
+    -- which means every driver kinda does what it wants with them...
+
+    -- So, at the very least, attempt to detect those that report it as a dBm value, because it'll be negative.
+    if self.signal_level < 0
+        return self.signal_level + 100
+    else
+        return self.signal_level
+    end
 end
 
 function WpaClient.__index:getScanResults()

--- a/wpaclient.lua
+++ b/wpaclient.lua
@@ -110,7 +110,7 @@ function network_mt.__index:getSignalQuality()
 
     local val = self.signal_level
     if val < 0 then
-        -- Assume dBm already; rough conversion: best = -30, worst = -100
+        -- Assume dBm already; rough conversion: best = -20, worst = -100
         val = dbm_to_qual(val)
     elseif val > 110 and val < 256 then
         -- assume old-style WEXT 8-bit unsigned signal level

--- a/wpaclient.lua
+++ b/wpaclient.lua
@@ -106,6 +106,7 @@ function network_mt.__index:getSignalQuality()
     local function dbm_to_qual(val)
         val = math.abs(clamp(val, -100, -20) + 20)    -- Normalize to 0
         val = 100 - math.floor((100.0 * val) / 80.0)  -- Make that a percentage
+        return val
     end
 
     local val = self.signal_level

--- a/wpaclient.lua
+++ b/wpaclient.lua
@@ -94,10 +94,12 @@ local network_mt = {__index = {}}
 function network_mt.__index:getSignalQuality()
     -- Make sure the RSSI is in a positive range (hopefully one that's in the ballpark of [0%, 100%]).
     -- There's no real silver bullet here, as the RSSI is in arbitrary units,
-    -- which means every driver kinda does what it wants with them...
+    -- which means every driver kinda does what it wants with it...
 
     -- So, at the very least, attempt to detect those that report it as a dBm value, because it'll be negative.
     if self.signal_level < 0
+        -- Actually hitting 0 dBm is highly unlikely, but, assuming [-100, 0] nonetheless appears to give consistent
+        -- results across the WiFi drivers used on Kobo devices...
         return self.signal_level + 100
     else
         return self.signal_level

--- a/wpaclient.lua
+++ b/wpaclient.lua
@@ -119,7 +119,7 @@ function network_mt.__index:getSignalQuality()
         val = val - 256                               -- Subtract 256 to convert to dBm
         val = dbm_to_qual(val)
     else
-        -- Assume signal is a already "quality" percentage
+        -- Assume signal is already a "quality" percentage
     end
 
     return clamp(val, 0, 100)

--- a/wpaclient.lua
+++ b/wpaclient.lua
@@ -121,13 +121,6 @@ function WpaClient.__index:getScanResults()
                 flags = splits[4],
                 ssid = splits[5],
             }
-            -- Old version of wpa_supplicant reports signal level in dBm, we
-            -- need to restrict it to range of [-192, 63] to keep it consistent
-            -- with new version.
-            -- ref: http://readlist.com/lists/shmoo.com/hostap/1/6589.html
-            if network.signal_level > 63 then
-                network.signal_level = network.signal_level - 0x100
-            end
             setmetatable(network, network_mt)
             table.insert(results, network)
         end


### PR DESCRIPTION
It seems to be doing more harm than good...

https://github.com/koreader/koreader/issues/7008

Instead, rely on dumber heuristics, that appear to be at least consistent across the Kobo devices I have, which do report RSSI in wildly different manners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/lj-wpaclient/6)
<!-- Reviewable:end -->
