### PR TITLE
Additional `isAuthSuccessful` recognized pattern

### DIFF
--- a/wpa_ctrl.lua
+++ b/wpa_ctrl.lua
@@ -20,7 +20,8 @@ math.randomseed(os.time())
 local event_mt = {__index = {}}
 
 function event_mt.__index:isAuthSuccessful()
-    return string.match(self.msg, '%w+: Key negotiation completed with (.+)') ~= nil
+    return (string.find(self.msg, 'CTRL%-EVENT%-CONNECTED')
+            or string.match(self.msg, '%w+: Key negotiation completed with (.+)') ~= nil)
 end
 
 function event_mt.__index:isScanEvent()


### PR DESCRIPTION
reMarkable 2 tablet no longer sends "Key negotiation completed" message when connection is made.
I don't know about the other devices using this library, so adding an `or` clause instead of replacing the existing check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/lj-wpaclient/7)
<!-- Reviewable:end -->
