### PR TITLE
Fix auth timeout match pattern

### DIFF
--- a/wpa_ctrl.lua
+++ b/wpa_ctrl.lua
@@ -21,7 +21,7 @@ local wpa_ctrl = {}
 
 function event_mt.__index:isAuthSuccessful()
     return (string.find(self.msg, "^CTRL%-EVENT%-CONNECTED")
-            or string.match(self.msg, "^%w+: Key negotiation completed with (.+)$") ~= nil)
+            or string.match(self.msg, "^WPA: Key negotiation completed with (.+)$") ~= nil)
 end
 
 function event_mt.__index:isScanEvent()
@@ -32,7 +32,7 @@ end
 
 function event_mt.__index:isAuthFailed()
     return (string.find(self.msg, "^CTRL%-EVENT%-DISCONNECTED")
-            or string.match(self.msg, "^Authentication with (.-) timed out$") ~= nil)
+            or string.match(self.msg, "^Authentication with (.-) timed out%.$") ~= nil)
 end
 
 local ev_lv2str = {


### PR DESCRIPTION
Turns out it's a proper sentence, and I fucked that up in #8 ;).

Also simplify the key nego match pattern (it's always WPA,
from rsn_supp/wpa.c).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/lj-wpaclient/9)
<!-- Reviewable:end -->
