### PR TITLE
Load ffi symbols individually, in protected mode

### DIFF
--- a/consts_h.lua
+++ b/consts_h.lua
@@ -1,11 +1,9 @@
 local ffi = require("ffi")
 
-ffi.cdef[[
-static const int AF_UNIX = 1;
-static const int SOCK_DGRAM = 2;
-static const int SOCK_NONBLOCK = 2048;
-static const int SOCK_CLOEXEC = 524288;
-static const int MSG_PEEK = 2;
-static const int MSG_NOSIGNAL = 16384;
-static const int EISCONN = 106;
-]]
+pcall(ffi.cdef, "static const int AF_UNIX = 1;")
+pcall(ffi.cdef, "static const int SOCK_DGRAM = 2;")
+pcall(ffi.cdef, "static const int SOCK_NONBLOCK = 2048;")
+pcall(ffi.cdef, "static const int SOCK_CLOEXEC = 524288;")
+pcall(ffi.cdef, "static const int MSG_PEEK = 2;")
+pcall(ffi.cdef, "static const int MSG_NOSIGNAL = 16384;")
+pcall(ffi.cdef, "static const int EISCONN = 106;")

--- a/poll_h.lua
+++ b/poll_h.lua
@@ -1,11 +1,11 @@
 local ffi = require("ffi")
 
-ffi.cdef[[
-static const int POLLIN = 1;
+pcall(ffi.cdef, "static const int POLLIN = 1;")
+pcall(ffi.cdef, [[
 struct pollfd {
   int fd;
   short int events;
   short int revents;
 };
-int poll(struct pollfd *, long unsigned int, int);
-]]
+]])
+pcall(ffi.cdef, "int poll(struct pollfd *, long unsigned int, int);")

--- a/select_h.lua
+++ b/select_h.lua
@@ -1,15 +1,15 @@
 local ffi = require("ffi")
 
-ffi.cdef[[
-typedef long int __fd_mask;
+pcall(ffi.cdef, "typedef long int __fd_mask;")
+pcall(ffi.cdef, [[
 typedef struct {
   __fd_mask __fds_bits[32];
 } fd_set;
-int select(int, fd_set *restrict, fd_set *restrict, fd_set *restrict, struct timeval *restrict);
+]])
+pcall(ffi.cdef, "int select(int, fd_set *restrict, fd_set *restrict, fd_set *restrict, struct timeval *restrict);")
 
-static const int POLLRDNORM = 64;
-static const int POLLRDBAND = 128;
-]]
+pcall(ffi.cdef, "static const int POLLRDNORM = 64;")
+pcall(ffi.cdef, "static const int POLLRDBAND = 128;")
 
 
 --[[

--- a/socket.lua
+++ b/socket.lua
@@ -1,19 +1,12 @@
 local cur_path = (...):match("(.-)[^%(.|/)]+$")
 local ffi = require("ffi")
 local C = ffi.C
--- We may already have some of these thanks to koreader-base ffi modules, hence the conditional loading
-if pcall(function() return C.AF_UNIX end) == false then
-    require(cur_path .. "consts_h")
-end
-if pcall(function() return C.socket end) == false then
-    require(cur_path .. "socket_h")
-end
-if pcall(function() return C.poll end) == false then
-    require(cur_path .. "poll_h")
-end
-if pcall(function() return C.select end) == false then
-    require(cur_path .. "select_h")
-end
+-- We may already have some of these thanks to koreader-base ffi modules,
+-- so we load each symbol one-by-one in a protected call...
+require(cur_path .. "consts_h")
+require(cur_path .. "socket_h")
+require(cur_path .. "poll_h")
+require(cur_path .. "select_h")
 
 
 local sockaddr_pt = ffi.typeof("struct sockaddr *")

--- a/socket_h.lua
+++ b/socket_h.lua
@@ -1,15 +1,15 @@
 local ffi = require("ffi")
 
-ffi.cdef[[
+pcall(ffi.cdef, [[
 struct sockaddr {
   short unsigned int sa_family;
   char sa_data[14];
 };
-int socket(int, int, int) __attribute__((nothrow, leaf));
-int bind(int, const struct sockaddr *, unsigned int) __attribute__((nothrow, leaf));
-int connect(int, const struct sockaddr *, unsigned int);
-ssize_t recvfrom(int, void *restrict, size_t, int, struct sockaddr *restrict, unsigned int *restrict);
-ssize_t recv(int, void *, size_t, int);
-ssize_t send(int, const void *, size_t, int);
-int close(int);
-]]
+]])
+pcall(ffi.cdef, "int socket(int, int, int) __attribute__((nothrow, leaf));")
+pcall(ffi.cdef, "int bind(int, const struct sockaddr *, unsigned int) __attribute__((nothrow, leaf));")
+pcall(ffi.cdef, "int connect(int, const struct sockaddr *, unsigned int);")
+pcall(ffi.cdef, "ssize_t recvfrom(int, void *restrict, size_t, int, struct sockaddr *restrict, unsigned int *restrict);")
+pcall(ffi.cdef, "ssize_t recv(int, void *, size_t, int);")
+pcall(ffi.cdef, "ssize_t send(int, const void *, size_t, int);")
+pcall(ffi.cdef, "int close(int);")

--- a/time_h.lua
+++ b/time_h.lua
@@ -1,10 +1,10 @@
 local ffi = require("ffi")
 
-ffi.cdef[[
-typedef long int time_t;
-typedef long int suseconds_t;
+pcall(ffi.cdef, "typedef long int time_t;")
+pcall(ffi.cdef, "typedef long int suseconds_t;")
+pcall(ffi.cdef, [[
 struct timeval {
   long int tv_sec;
   long int tv_usec;
 };
-]]
+]])

--- a/wpa_ctrl.lua
+++ b/wpa_ctrl.lua
@@ -3,14 +3,15 @@ local ffi = require("ffi")
 local C = ffi.C
 local Socket = require(cur_path .. "socket")
 
-ffi.cdef[[
-unsigned int sleep(unsigned int seconds);
+
+pcall(ffi.cdef, "unsigned int sleep(unsigned int seconds);")
+pcall(ffi.cdef, [[
 struct sockaddr_un {
   short unsigned int sun_family;
   char sun_path[108];
 };
-int unlink(const char *) __attribute__((nothrow, leaf));
-]]
+]])
+pcall(ffi.cdef, "int unlink(const char *) __attribute__((nothrow, leaf));")
 
 
 local sockaddr_un_t = ffi.typeof("struct sockaddr_un")

--- a/wpa_ctrl.lua
+++ b/wpa_ctrl.lua
@@ -3,7 +3,6 @@ local ffi = require("ffi")
 local C = ffi.C
 local Socket = require(cur_path .. "socket")
 
-
 pcall(ffi.cdef, "unsigned int sleep(unsigned int seconds);")
 pcall(ffi.cdef, [[
 struct sockaddr_un {
@@ -12,7 +11,6 @@ struct sockaddr_un {
 };
 ]])
 pcall(ffi.cdef, "int unlink(const char *) __attribute__((nothrow, leaf));")
-
 
 local sockaddr_un_t = ffi.typeof("struct sockaddr_un")
 


### PR DESCRIPTION
To avoid conflicts with koreader-base once and for all...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/lj-wpaclient/10)
<!-- Reviewable:end -->
