### PR TITLE
Add support for MIPS architecture

### DIFF
--- a/consts_def_h.lua
+++ b/consts_def_h.lua
@@ -1,0 +1,5 @@
+local ffi = require("ffi")
+
+pcall(ffi.cdef, "static const int SOCK_DGRAM = 2;")
+pcall(ffi.cdef, "static const int SOCK_NONBLOCK = 2048;")
+pcall(ffi.cdef, "static const int EISCONN = 106;")

--- a/consts_h.lua
+++ b/consts_h.lua
@@ -1,11 +1,16 @@
+local cur_path = (...):match("(.-)[^%(.|/)]+$")
 local ffi = require("ffi")
 
+-- Handle arch-dependent typedefs...
+if ffi.arch == "mips" then
+    require(cur_path .. "consts_mips_h")
+else
+    require(cur_path .. "consts_def_h")
+end
+
 pcall(ffi.cdef, "static const int AF_UNIX = 1;")
-pcall(ffi.cdef, "static const int SOCK_DGRAM = 2;")
-pcall(ffi.cdef, "static const int SOCK_NONBLOCK = 2048;")
 pcall(ffi.cdef, "static const int SOCK_CLOEXEC = 524288;")
 pcall(ffi.cdef, "static const int MSG_PEEK = 2;")
 pcall(ffi.cdef, "static const int MSG_NOSIGNAL = 16384;")
 pcall(ffi.cdef, "static const int EINTR = 4;")
 pcall(ffi.cdef, "static const int EAGAIN = 11;")
-pcall(ffi.cdef, "static const int EISCONN = 106;")

--- a/consts_mips_h.lua
+++ b/consts_mips_h.lua
@@ -1,0 +1,5 @@
+local ffi = require("ffi")
+
+pcall(ffi.cdef, "static const int SOCK_DGRAM = 1;")
+pcall(ffi.cdef, "static const int SOCK_NONBLOCK = 128;")
+pcall(ffi.cdef, "static const int EISCONN = 133;")

--- a/select_64b_h.lua
+++ b/select_64b_h.lua
@@ -1,0 +1,8 @@
+local ffi = require("ffi")
+
+pcall(ffi.cdef, "typedef long int __fd_mask;")
+pcall(ffi.cdef, [[
+typedef struct {
+  __fd_mask __fds_bits[16];
+} fd_set;
+]])

--- a/select_def_h.lua
+++ b/select_def_h.lua
@@ -1,0 +1,8 @@
+local ffi = require("ffi")
+
+pcall(ffi.cdef, "typedef long int __fd_mask;")
+pcall(ffi.cdef, [[
+typedef struct {
+  __fd_mask __fds_bits[32];
+} fd_set;
+]])

--- a/select_h.lua
+++ b/select_h.lua
@@ -1,11 +1,12 @@
+local cur_path = (...):match("(.-)[^%(.|/)]+$")
 local ffi = require("ffi")
 
-pcall(ffi.cdef, "typedef long int __fd_mask;")
-pcall(ffi.cdef, [[
-typedef struct {
-  __fd_mask __fds_bits[32];
-} fd_set;
-]])
+-- Handle arch-dependent typedefs...
+if ffi.abi("64bit") then
+    require(cur_path .. "select_64b_h")
+else
+    require(cur_path .. "select_def_h")
+end
 pcall(ffi.cdef, "int select(int, fd_set *restrict, fd_set *restrict, fd_set *restrict, struct timeval *restrict);")
 
 pcall(ffi.cdef, "static const int POLLRDNORM = 64;")


### PR DESCRIPTION
Many small routers running OpenWRT still use the MIPS architecture. This merge request enables `lj-wpaclient` to work on those devices.

Also contains a fix for struct fd_set definition on 64 bit systems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/lj-wpaclient/16)
<!-- Reviewable:end -->
